### PR TITLE
update for 22.10 release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,13 +1,13 @@
 latest:
-  slug: ImpishIndri
-  name: "Impish Indri"
-  short_version: "21.10"
-  full_version: "21.10"
-  core_version: "20"
-  release_date: "October 2021"
-  eol: "2022年7月"
+  slug: KineticKudu
+  name: "Kinetic Kudu"
+  short_version: "22.10"
+  full_version: "22.10"
+  core_version: "22"
+  release_date: "October 2022"
+  eol: "2023年7月"
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/impish-indri-release-notes/21951"
+  release_notes_url: "https://discourse.ubuntu.com/t/kinetic-kudu-release-notes/27976"
 lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
@@ -31,26 +31,32 @@ openstack_lts:
 
 checksums:
   desktop:
+    "22.10": "b98f13cd86839e70cb7757d46840230496b3febea309dd73bd5f81383474e47b *ubuntu-22.10-desktop-amd64.iso"
     "22.04.1": "c396e956a9f52c418397867d1ea5c0cf1a99a49dcf648b086d2fb762330cc88d *ubuntu-22.04.1-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.4": "f92f7dca5bb6690e1af0052687ead49376281c7b64fbe4179cc44025965b7d1c *ubuntu-20.04.4-desktop-amd64.iso"
   live-server:
+    "22.10": "874452797430a94ca240c95d8503035aa145bd03ef7d84f9b23b78f3c5099aed *ubuntu-22.10-live-server-amd64.iso"
     "22.04.1": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb *ubuntu-22.04.1-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.4": "28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad *ubuntu-20.04.4-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
+    "22.10": "c9cf57399a5e3e3a9803740f8107ef52891b7d3ac293106d3257396b75ddf7de *ubuntu-22.10-preinstalled-desktop-arm64+raspi.img.xz"
     "22.04.1": "680c2c1770b53d90e825fd9a40178f605af47acfff681ad5f68d38094d1c32eb *ubuntu-22.04.1-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
+    "22.10": "170d860a49039499d349eeb69276c997e26ada811f5b4bce761b55a6461914a2 *ubuntu-22.10-preinstalled-server-arm64+raspi.img.xz"
     "22.04.1": "5d0661eef1a0b89358159f3849c8f291be2305e5fe85b7a16811719e6e8ad5d1 *ubuntu-22.04.1-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.4": "6aeba20c00ef13ee7b48c57217ad0d6fc3b127b3734c113981d9477aceb4dad7 *ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
+    "22.10": "a869ade13fb1a983da95eb92093e640692a930d01354d63f05571234ca0cd6b5 *ubuntu-22.10-preinstalled-server-armhf+raspi.img.xz"
     "22.04.1": "342fb581ce11208c26f35675acafdc3d56ac2838b1297a508e602f88606903f1 *ubuntu-22.04.1-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.4": "3b1704e8e4ff8e01dd89b9dd6adf9b99b48b2a7530d6f7676ce8c37772ff4178 *ubuntu-20.04.4-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
+    "22.10": "858feb7f96e94ad904624262ee4a669caebafd012a2812e19e0dd21be9b6faa6 *ubuntu-22.10-preinstalled-server-riscv64+unmatched.img.xz"
     "22.04.1": "a4cf79456e09c7c03c96ef4b0924dd54ab1706d86af09d29a7c117855e80eac6 *ubuntu-22.04.1-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -32,13 +32,13 @@
     </div>
     <div class="col-6 u-hide--medium u-align--center u-hide--small">
       {{ image (
-      url="https://assets.ubuntu.com/v1/fe859a7f-Jammy+Jellyfish+RGB.svg",
-      alt="",
-      width="260",
-      height="150",
-      hi_def=True,
-      loading="auto"
-      ) | safe
+        url="https://assets.ubuntu.com/v1/beadabd5-mascots_kudu-jelly.svg",
+        alt="",
+        width="540",
+        height="195",
+        hi_def=True,
+        loading="auto"
+        ) | safe
       }}
     </div>
   </div>

--- a/templates/download/raspberry-pi.html
+++ b/templates/download/raspberry-pi.html
@@ -33,20 +33,18 @@
 </section>
 
 
-{# desktop latest #}
+{# desktop lts #}
 <section class="p-strip--light">
   <div class="row">
     <div class="col-6">
       <h2 class="u-sv2">
         下载Ubuntu桌面版
       </h2>
-      <p class="p-muted-heading">
-        推荐的桌面版
-      </p>
     </div>
   </div> 
   <div class="row">
     <div class="col-6">
+      <p class="p-muted-heading">&nbsp;</p>
       <h3>
         Ubuntu 桌面 {{ releases.lts.full_version }} LTS
       </h3>
@@ -62,17 +60,27 @@
       </p>
     </div>
 
-    <div class="col-4 u-vertically-center u-align--center u-hide--small u-hide--medium">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/fe859a7f-Jammy+Jellyfish+RGB.svg",
-        alt="",
-        width="260",
-        height="150",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
+    {# desktop latest #}
+    {% if releases.latest.short_version > releases.lts.short_version %}
+    <div class="col-6">
+      <p class="p-muted-heading">
+        推荐的桌面版
+      </p>
+      <h3>
+        Ubuntu 桌面 {{ releases.latest.full_version }}
+      </h3>
+      <p>
+        最新的Ubuntu开发版本，拥有5年的长期支持，至{{ releases.latest.eol }}。
+      </p>
+      <p>
+        <a
+        class="p-button--positive"
+        href="https://cdimage.ubuntu.com/releases/{{ releases.latest.full_version }}/release/ubuntu-{{ releases.latest.full_version }}-preinstalled-desktop-arm64+raspi.img.xz" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+        下载64位镜像
+        </a>
+      </p>
     </div>
+    {% endif %}
   </div>
 
   <div class="u-hide--medium u-hide--large">

--- a/templates/download/server/step1.html
+++ b/templates/download/server/step1.html
@@ -95,15 +95,14 @@
 
       <div class="col-5 u-vertically-center u-align--center u-hide--small">
         <div class="">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/c9a911d5-II-grad-mascot.svg",
-              alt="",
-              height="150",
-              width="263",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
+          {{ image (
+            url="https://assets.ubuntu.com/v1/38ba52dc-Kinetic+Kudo+22.10.svg",
+            alt="",
+            width="288",
+            height="250",
+            hi_def=True,
+            loading="auto"
+            ) | safe
           }}
         </div>
       </div>    


### PR DESCRIPTION
## Done

- updated list of checksums and releases.yaml latest
- updated mascot on /download
- updated mascot /download/server
- added 22.10 section to /download/raspberry-pi to match what's going live on ubuntu.com for the release (a 22.10 desktop download cta that sits alongside the LTS listing)

## QA

- Visit https://cn-ubuntu-com-649.demos.haus/download
- See that the mascot is correct
- Visit https://cn-ubuntu-com-649.demos.haus/download/desktop
- See that 22.10 is listed with links to download it (the links won't work yet)
- Visit https://cn-ubuntu-com-649.demos.haus/download/server/step1
- See that the mascot is correct and that 22.10 is listed with links to download it (the links won't work yet)
- Visit  https://cn-ubuntu-com-649.demos.haus/download/raspberry-pi
- See that 22.10 is listed with links to download it (the links won't work yet)

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12210
