### PR TITLE
Fix takeover image

### DIFF
--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -24,7 +24,7 @@
       title=takeover['title'],
       subtitle=takeover['subtitle'],
       class="p-takeover--" + takeover['class'],
-      header_image=takeover['image'],
+      header_image=takeover['header_image'],
       image_style="width: " + takeover['image_width'] + "px; height: " + takeover['image_height'] + "px; ",
       image_hide_small="true",
       primary_url=takeover['primary_url'],


### PR DESCRIPTION
## Done

Fix image in ubuntu takeovers

## QA

Go to https://cn-ubuntu-com-657.demos.haus/takeovers all images are showing now (in contrast https://cn.ubuntu.com/takeovers is not showing images)

## Issue / Card

Fixes https://github.com/canonical/cn.ubuntu.com/issues/656