### PR TITLE
Add ga tracking for takeover impressions

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1497,6 +1497,14 @@
       secondaryUrl.href = selectedTakeover.secondary_url;
       secondaryUrl.innerHTML = selectedTakeover.secondary_cta + "&nbsp;&rsaquo;";
     }
+
+    dataLayer.push({
+      event: "NonInteractiveGAEvent",
+      eventCategory: "www.ubuntu.com-impression-takeover",
+      eventAction: "from:" + window.location.href + " to:" + selectedTakeover.primary_url,
+      eventLabel: selectedTakeover.primary_cta,
+      eventValue: undefined,
+    });
   }
 </script>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1500,9 +1500,9 @@
 
     dataLayer.push({
       event: "NonInteractiveGAEvent",
-      eventCategory: "www.ubuntu.com-impression-takeover",
-      eventAction: "from:" + window.location.href + " to:" + selectedTakeover.primary_url,
-      eventLabel: selectedTakeover.primary_cta,
+      eventCategory: "cn.ubuntu.com-impression-takeover",
+      eventAction: "CTA click",
+      eventLabel: selectedTakeover.title,
       eventValue: undefined,
     });
   }


### PR DESCRIPTION
## Done

- Adds ga tracking for takeover impressions

## QA

- Load the homepage (make sure a takeover loads) and check the ga event has been pushed with the appropriate data
Two ways to do this:
1. run the branch locally follow the guide in the [google analytic docs](https://developers.google.com/analytics/devguides/collection/analyticsjs/events) to see tga events in the network tab
2. (Recommended) Download a broswer extension that tracks GA events, I am using [tag legacy](https://chrome.google.com/webstore/detail/tag-assistant-legacy-by-g/kejbdjndbnbjgmefkgdddjlbokphdefk)

Should look something like: 
```
{
"gtm.start" : 1678275907959 ,
"event" : "gtm.js" ,
"gtm.uniqueEventId" : 1
},
{
"event" : "gtm.dom" ,
"gtm.uniqueEventId" : 2
},
{
"event" : "NonInteractiveGAEvent" ,
"eventCategory" : "www.ubuntu.com-impression-takeover" ,
"eventAction" : "from:http://0.0.0.0:8010/ to:/engage/top-five-iot-challenges-cn?utm_medium=takeover" ,
"eventLabel" : "立即下载" ,
"gtm.uniqueEventId" : 3
},
{
"event" : "gtm.load" ,
"gtm.uniqueEventId" : 4
}
```

## Issue / Card

https://warthogs.atlassian.net/browse/WD-2462
