### PR TITLE
WD-5437 Add acquisition URL

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -34,6 +34,7 @@
 
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
         <input value="3647" name="formid" type="hidden">
+        <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/contact/index.html
+++ b/templates/contact/index.html
@@ -65,6 +65,7 @@
           <button type="submit" class="u-no-margin--bottom p-card--content" style="width:50%"> 提交 </button>
           <input name="formid" aria-label="formid" value="2816" type="hidden">
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+          <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -92,6 +92,7 @@
             <button type="submit" class="u-no-margin--bottom">订阅和下载</button>
             <input name="formid" aria-label="formid" value="3593" type="hidden">
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+            <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/engage/2004-launch.html
+++ b/templates/engage/2004-launch.html
@@ -88,6 +88,7 @@
          <button type="submit" class="u-no-margin--bottom">观看录制视频</button>
          <input name="formid" aria-label="formid" value="3563" type="hidden">
          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+         <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/engage/shared/_engage_form.html
+++ b/templates/engage/shared/_engage_form.html
@@ -37,6 +37,7 @@
         <button type="submit" class="u-no-margin--bottom">{{ cta }}</button>
         <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+        <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />


### PR DESCRIPTION
## Done

Add acquisition URLs for marketo to obtain the full path.

## QA

- Go to https://cn-ubuntu-com-703.demos.haus/blog/canonical-ubuntu-core-22-is-now-available-optimised-for-iot-and-embedded-devices-cn
- Submit the newsletter form on the right.
- You should receive the acquisition URL now in Marketo.


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5437

## Screenshots

[if relevant, include a screenshot]
