### PR TITLE
Add ICP to footer template

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -4,6 +4,7 @@
   <div class="row">
     <div class="col-12">
       <p>&copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>
+      <p><a href="https://beian.miit.gov.cn">京ICP备20013621号-2</a></p>
       <nav>
         <ul class="p-inline-list--middot">
           <li class="p-inline-list__item">


### PR DESCRIPTION
## Done

Add our ICP number to the page footer, to unblock China-hosted mirroring of the site (ISDB-1338).