### PR TITLE
Define MIME type for blog rss feed

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -6,6 +6,9 @@
   {% include "blog/featured-articles.html" %}
 {% endif %}
 
+{% block extra_metatags %}
+  <link rel="alternate" type="application/rss+xml"  href="/blog/feed" title="Ubuntu.com's Blog RSS feed">
+{% endblock %}
 
 <section class="p-strip is-shallow">
   <div class="row u-equal-height u-clearfix">

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -7,7 +7,7 @@
 {% endif %}
 
 {% block extra_metatags %}
-  <link rel="alternate" type="application/rss+xml"  href="/blog/feed" title="Ubuntu.com's Blog RSS feed">
+  <link rel="alternate" type="application/rss+xml"  href="/blog/feed" title="cn.ubuntu.com's Blog RSS feed">
 {% endblock %}
 
 <section class="p-strip is-shallow">


### PR DESCRIPTION
## Done

- Explicitly defined MIME type for blog feed as we do on [u.com
](https://github.com/canonical/ubuntu.com/blob/3774902ecc0c2d9356fcf8d68ee6fb16485f91a7/templates/blog/index.html#L5)

## QA

- This is an experimental fix for the bug(s) reported, I can't really think of a way to QA this locally without having access to Perkuto so just code review is needed

## Issue / Card

Issue flagged in MM, [see thread](https://chat.canonical.com/canonical/pl/78zxi9hdgtfspe311tczij7s3e)

