### PR TITLE
chore: Update ceph storage capacity information

### DIFF
--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -110,7 +110,7 @@
   <section class="p-strip--light is-shallow" id="storage">
     <div class="u-fixed-width">
       <h2 class="p-heading--3">软件订阅存储 &ndash; Ceph 和 Swift</h2>
-      <p>仅适用于集群中每个节点附加超过 192TB 的原始 Ceph/Swift 容量。定价超过 Ubuntu Pro 中每个节点 192TB 的总量。</p>
+      <p>仅适用于集群中每个节点附加超过 384TB 的原始 Ceph/Swift 容量。定价超过 Ubuntu Pro 中每个节点 384TB 的总量。</p>
     </div>
     {% include "shared/pricing/_ua-advanced-storage.html" %}
     <div class="u-fixed-width">


### PR DESCRIPTION
## Done

- Increased the allowed storage capacity per node from '192TB' to '384TB'. More details can be found in [the issue](https://warthogs.atlassian.net/browse/WD-16414) (there is no copydoc)

## QA

- Open the demo: https://cn-ubuntu-com-739.demos.haus/pricing/pro
- Check that the change of  '192TB' to '384TB' have been applied

## Issue / Card

[[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]](https://warthogs.atlassian.net/browse/WD-16414)
