### PR TITLE
[WD-277058] chore: Update releases

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,24 +1,24 @@
 latest:
-  slug: OracularOriole
-  name: 'Oracular Oriole'
-  short_version: '24.10'
-  full_version: '24.10'
-  desktop_version: '24.10'
+  slug: PluckyPuffin
+  name: 'Plucky Puffin'
+  short_version: '25.04'
+  full_version: '25.04'
+  desktop_version: '25.04'
   core_version: '24'
-  release_date: '2024年10月'
-  eol: '2025年7月'
+  release_date: '2025年4月'
+  eol: '2026年1月'
   past_eol_date: false
-  release_notes_url: 'https://discourse.ubuntu.com/t/oracular-oriole-release-notes/44878'
-  iso_download_size: '5.3GB'
-  server_iso_size: '2.0GB'
-  raspi_desktop_iso_size: '2.7GB'
+  release_notes_url: 'https://discourse.ubuntu.com/t/plucky-puffin-release-notes'
+  iso_download_size: '5.8GB'
+  server_iso_size: '1.9GB'
+  raspi_desktop_iso_size: '2.9GB'
   raspi_server_iso_size: '1.2GB'
   rasp_pi_core_24_size: '314MB'
 lts:
   slug: NobleNumbat
   name: 'Noble Numbat'
   short_version: '24.04'
-  full_version: '24.04.2'
+  full_version: '24.04.3'
   release_date: '2024年4月'
   eol: '2029年4月'
   release_notes_url: 'https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890'


### PR DESCRIPTION
## Done

- Update desktop releases

## QA

- Go to https://cn-ubuntu-com-773.demos.haus/download/desktop
- Make sure 24.04.3 and 25.04 are listed
- Download both to make sure the download links work

## Issue / Card

[WD-2058](https://warthogs.atlassian.net/browse/WD-27058)

[WD-2058]: https://warthogs.atlassian.net/browse/WD-2058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ