### PR TITLE
fix: Extract engage page topics from metadata tuple

### DIFF
--- a/templates/engage/base_engage.html
+++ b/templates/engage/base_engage.html
@@ -1,114 +1,124 @@
 {% extends "templates/base.html" %}
 
-{% set section_title="Engage Page" %}
-{% set section_path="/engage" %}
+{% set section_title = "Engage Page" %}
+{% set section_path = "/engage" %}
 
-{% block title %}{{metadata['topic_name']}}{% endblock %}
-{% block meta_description %}{{metadata['subtitle']}}{% endblock %}
-{% block meta_image %}{{metadata['meta_image']}}{% endblock %}
+{% block title %}{{ metadata['topic_name'] }}{% endblock %}
 
-{% block meta_copydoc %}{metadata["meta_copydoc]}{% endblock meta_copydoc %}
+{% block meta_description %}{{ metadata['subtitle'] }}{% endblock %}
+
+{% block meta_image %}{{ metadata['meta_image'] }}{% endblock %}
+
+{% block meta_copydoc %}
+  {metadata["meta_copydoc]}
+{% endblock meta_copydoc %}
 
 {% block content %}
 
-<section class="p-strip p-engage-banner--{{metadata['banner_class']}}">
-  <div class="u-fixed-width navigation-logo-engage">
-    <a href="/">
-      {% if metadata['banner_class'] == 'light' %}
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg",
-            alt="Ubuntu",
-            height="32",
-            width="143",
-            hi_def=True,
-            loading="auto"
-          ) | safe
-        }}
-      {% else %}
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
-            alt="Ubuntu",
-            height="32",
-            width="143",
-            hi_def=True,
-            loading="auto"
-          ) | safe
-        }}
-      {% endif %}
-
-    </a>
-  </div>
-  <div class="row">
-    <div class="col-7 u-vertically-center">
-      <h1>{{metadata["topic_name"]}}</h1>
-      <p class="u-no-padding--top p-heading--4">
-        {{metadata['subtitle']}}
-      </p>
-      {% if ("primary_cta" in metadata) and (metadata["primary_cta"] != "") %}
-      <p class="{% if 'secondary_cta' not in metadata %}u-hide--large{% endif %}">
-          <a href="{{ metadata['primary_link'] }}" class="p-button--positive">
-            {{ metadata["primary_cta"] }}
-          </a>
-        {% if ("secondary_cta" in metadata) and (metadata["secondary_cta"] != "") %}
-          <a href="{{ metadata['secondary_link'] }}" class="p-button">
-            {{metadata['secondary_cta']}}
-          </a>
+  <section class="p-strip p-engage-banner--{{ metadata['banner_class'] }}">
+    <div class="u-fixed-width navigation-logo-engage">
+      <a href="/">
+        {% if metadata['banner_class'] == 'light' %}
+          {{ image(url="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg",
+                    alt="Ubuntu",
+                    height="32",
+                    width="143",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        {% else %}
+          {{ image(url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+                    alt="Ubuntu",
+                    height="32",
+                    width="143",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
         {% endif %}
-      </p>
-      {% endif %}
+
+      </a>
     </div>
-    {% if metadata["image"] != '' %}
-    <div class="col-5 u-hide--small u-vertically-center u-align--center">
-      <img src="{{metadata['image']}}" alt="" width="{{metadata['image_width']}}"/>
-    </div>
-    {% endif %}
-  </div>
-</section>
-
-
-
-<section class="p-strip is-shallow is-bordered">
-  <div class="row">
-    <div class="{% if metadata['form_id'] != '' %}col-7{% else %}col-8{% endif %}">
-      {{ metadata["body_html"] | safe }}
-    </div>
-    {% if metadata["form_id"] != "" %}
-    <div class="col-5" id="the-form">
-      {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
-        {% with id=metadata["form_id"], returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'] %}
-          {% include "engage/shared/_engage_form.html" %}
-        {% endwith %}
-      {% else %}
-      {% with id=metadata["form_id"], returnURL=metadata['path']+"/thank-you", cta="提交" %}
-        {% include "engage/shared/_engage_form.html" %}
-      {% endwith %}
-      {% endif %}
-
-    </div>
-    {% endif %}
-  </div>
-
-</section>
-
-{% if metadata["webinar_code"] != "" %}
-  {% if "channel_id" in metadata %}
-    {% set channel_id = metadata["channel_id"] %}
-  {% else %}
-    {% set channel_id = 6793 %}
-  {% endif %}
-  <!-- webinar -->
-  <section class="p-strip is-shallow" id="register-section">
-    <div class="row" id="webinar">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
-        <script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : {{channel_id}}, "language": "cn-ZH", "commId" : {{ metadata["webinar_code"] }}, "displayMode" : "standalone", "height" : "auto" }</script>
-        <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+    <div class="row">
+      <div class="col-7 u-vertically-center">
+        <h1>{{ metadata["topic_name"] }}</h1>
+        <p class="u-no-padding--top p-heading--4">{{ metadata['subtitle'] }}</p>
+        {% if ("primary_cta" in metadata) and (metadata["primary_cta"] != "") %}
+          <p class="{% if 'secondary_cta' not in metadata %}u-hide--large{% endif %}">
+            <a href="{{ metadata['primary_link'] }}" class="p-button--positive">{{ metadata["primary_cta"] }}</a>
+            {% if ("secondary_cta" in metadata) and (metadata["secondary_cta"] != "") %}
+              <a href="{{ metadata['secondary_link'] }}" class="p-button">{{ metadata['secondary_cta'] }}</a>
+            {% endif %}
+          </p>
+        {% endif %}
       </div>
+      {% if metadata["image"] != '' %}
+        <div class="col-5 u-hide--small u-vertically-center u-align--center">
+          <img src="{{ metadata['image'] }}"
+               alt=""
+               width="{{ metadata['image_width'] }}" />
+        </div>
+      {% endif %}
     </div>
   </section>
-{% endif %}
+
+  <section class="p-strip is-shallow is-bordered">
+    <div class="row">
+      <div class="{% if metadata['form_id'] != '' %}col-7{% else %}col-8{% endif %}">{{ metadata["body_html"] | safe }}</div>
+      {% if metadata["form_id"] != "" %}
+        <div class="col-5" id="the-form">
+          {% if "form_cta" in metadata and metadata["form_cta"] != '' %}
+            {% with id=metadata["form_id"], returnURL=metadata['path']+"/thank-you", cta=metadata['form_cta'] %}
+              {% include "engage/shared/_engage_form.html" %}
+            {% endwith %}
+          {% else %}
+            {% with id=metadata["form_id"], returnURL=metadata['path']+"/thank-you", cta="提交" %}
+              {% include "engage/shared/_engage_form.html" %}
+            {% endwith %}
+          {% endif %}
+
+        </div>
+      {% endif %}
+    </div>
+
+  </section>
+
+  {% if metadata["webinar_code"] != "" %}
+    {% if "channel_id" in metadata %}
+      {% set channel_id = metadata["channel_id"] %}
+    {% else %}
+      {% set channel_id = 6793 %}
+    {% endif %}
+    <!-- webinar -->
+    <section class="p-strip is-shallow" id="register-section">
+      <div class="row" id="webinar">
+        <div class="jsBrightTALKEmbedWrapper"
+             style="width:100%;
+                    height:100%;
+                    position:relative;
+                    background: #ffffff">
+          <script class="jsBrightTALKEmbedConfig" type="application/json">
+            {
+              "channelId": {
+                {
+                  channel_id
+                }
+              },
+              "language": "cn-ZH",
+              "commId": {
+                {
+                  metadata["webinar_code"]
+                }
+              },
+              "displayMode": "standalone",
+              "height": "auto"
+            }
+          </script>
+          <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js"
+                  class="jsBrightTALKEmbed"></script>
+        </div>
+      </div>
+    </section>
+  {% endif %}
 
 
 {% endblock content %}
-

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -104,7 +104,8 @@ def takeovers_json():
 
 
 def takeovers_index():
-    all_takeovers = discourse_takeovers.get_index()
+    result = discourse_takeovers.get_index()
+    all_takeovers = result[0]
     all_takeovers.sort(
         key=lambda takeover: takeover["active"] == "true", reverse=True
     )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -15,13 +15,13 @@ def build_engage_index(engage_docs):
         sort = flask.request.args.get("sort", default=None, type=str)
         posts_per_page = 15
         metadata = engage_docs.get_index()
+        topics = metadata[0]
 
-        total_pages = math.ceil(len(metadata) / posts_per_page)
-
+        total_pages = math.ceil(len(topics) / posts_per_page)
         return flask.render_template(
             "engage/index.html",
             forum_url=engage_docs.api.base_url,
-            metadata=metadata,
+            metadata=topics,
             page=page,
             topic=topic,
             sort=sort,


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

engage
takeovers
## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
